### PR TITLE
Some refactoring, add support for properly mapping with arrays, false…

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,26 +1,25 @@
 "use strict";
 
-const _ = require("lodash");
+const isObject = require("lodash/fp/isObject");
+const isArray = require("lodash/fp/isArray");
+const mapKeys = require("lodash/fp/mapKeys");
 
-module.exports = function mapKeysDeepLodash(obj, cb) {
-  if (_.isUndefined(obj)) {
-    throw new Error(`map-keys-deep-lodash expects an object but got ${typeof obj}`);
-  }
+const toKeyValuePair = (obj) => (key) => ({ key, val: obj[key] });
 
-  obj = _.mapKeys(obj, cb);
-
-  const res = {};
-
-  for (const key in obj) {
-    if (obj.hasOwnProperty(key)) {
-      const val = obj[key];
-      if (_.isObject(val)) {
-        res[key] = mapKeysDeepLodash(val, cb);
-      } else {
-        res[key] = val;
-      }
-    }
-  }
-
-  return res;
+const mapKeyValueToObject = (cb) => (mutateObj, {key, val}) => {
+  mutateObj[cb(key)] = mapKeysDeep(cb)(val);
+  return mutateObj;
 };
+
+const mapKeysObject = (cb, obj) => Object.keys(obj).map(toKeyValuePair(obj)).reduce(mapKeyValueToObject(cb), {}); 
+
+const mapKeysDeep = (cb) => (val) => {
+  if(!val) { return val; }
+  if(isArray(val)) { return mapKeysArray(cb, val); }
+  if(isObject(val)) { return mapKeysObject(cb, val); }
+  return val;
+};
+
+const mapKeysArray = (cb, arr) => arr.map(mapKeysDeep(cb));
+
+module.exports = (callBack, value) => mapKeysDeep(callBack)(value);

--- a/test.js
+++ b/test.js
@@ -3,26 +3,31 @@
 const assert = require("assert");
 const expect = require("chai").expect;
 
-const mapKeysDeep = require("./");
+const mapKeysDeep = require("./index.js");
+const camelCase = require("lodash/fp/camelCase");
 
 describe(".mapKeysDeep()", () => {
-  expect(() => {
-    mapKeysDeep(undefined);
-  }).to.throw("map-keys-deep-lodash expects an object but got undefined");
+  it('converts to camel case', () => {
+    const out = mapKeysDeep(camelCase, { "display-name": true })
+    expect(out.displayName).to.be.equal(true)
+  })
 
-  const foo = mapKeysDeep({a: "b", c: "d", e: {c: "f", g: {c: "h"}}}, (value, key) => {
-    if (key === "c") {
-      return "zzz";
-    }
-    return key;
-  });
-  assert.deepEqual(foo, {a: "b", zzz: "d", e: {zzz: "f", g: {zzz: "h"}}});
+  it('converts an array', () => {
+    const out = mapKeysDeep(camelCase, [1, true, { "display-name": true }, null])
+    expect(out[0]).to.be.equal(1)
+    expect(out[1]).to.be.equal(true)
+    expect(out[2].displayName).to.be.equal(true)
+    expect(out[3]).to.be.equal(null)
+  })
 
-  const bar = mapKeysDeep({a: {a: {a: "b"}}}, (value, key) => {
-    if (key === "a") {
-      return "zzz";
-    }
-    return key;
-  });
-  assert.deepEqual(bar, {zzz: {zzz: {zzz: "b"}}});
+  it('converts deep object properties', () => {
+    const out = mapKeysDeep(camelCase, { "foo-bar": { "baz-buzz": { "wat-wat": true } } })
+    expect(out.fooBar.bazBuzz.watWat).to.be.equal(true)
+  })
+
+  it('converts deep arrays', () => {
+    const out = mapKeysDeep(camelCase, [ [ [ { "foo-bar": "bazz-buzz" } ] ] ])
+    expect(out[0][0][0].fooBar).to.be.equal('bazz-buzz')
+  })
+
 });


### PR DESCRIPTION
…y things are returned instead of throwing

Hey! Thanks for making this cool little utility library... I have made these changes:

- Instead of throwing for falsey values, just return whatever was provided
- Add support for handling arrays (both as the root object or as a descendant in the object being mapped over)
- Object.keys() is expected to be faster than for..in + Object.hasOwnProperty (IE9+)
- Wrote functions as fat arrow/lambda (IE Edge+). If you want to maintain support with legacy IE, I can convert these back to `function`

If you'd like to accept the PR but have some changes you think should be made, please let me know as I'd like to contribute :)